### PR TITLE
Introduce numRecordsOutPerSecond metric for Custom Autoscaler Decision Making

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
@@ -104,7 +104,8 @@ public class ScalingExecutor {
         }
 
         scalingInformation.addToScalingHistory(clock.instant(), scalingSummaries, conf);
-        // TODO add my service to get metrics form the custom autscaler and pass it to the below function.
+        // TODO add my service to get metrics form the custom autscaler and pass it to the below
+        // function.
         // HashMap<String, String> test = ScalingMetricJsonSender.getDataFromEndpoint();
         scalingInformation.setCurrentOverrides(
                 getVertexParallelismOverrides(evaluatedMetrics, scalingSummaries));

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
@@ -140,6 +140,7 @@ public abstract class ScalingMetricCollector {
             LOG.info("Metric window not full until {}", windowFullTime);
         }
 
+        // TODO: sending metrics to the REST endpoint.
         ScalingMetricJsonSender.sendMetricsAsJson(collectedMetrics);
         HashMap<String, String> test = ScalingMetricJsonSender.getDataFromEndpoint();
 

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetric.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetric.java
@@ -61,6 +61,8 @@ public enum ScalingMetric {
     /** Lower boundary of the target data rate range. */
     SCALE_DOWN_RATE_THRESHOLD(false),
 
+    NUM_RECORDS_OUT_PER_SECOND(true),
+
     /** Expected true processing rate after scale up. */
     EXPECTED_PROCESSING_RATE(false);
 

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
@@ -59,6 +59,7 @@ public class ScalingMetrics {
         double busyTimeMsPerSecond = getBusyTimeMsPerSecond(flinkMetrics, conf, jobVertexID);
         double numRecordsInPerSecond =
                 getNumRecordsInPerSecond(flinkMetrics, jobVertexID, isSource);
+        double numRecordsOutPerSecond = getNumRecordsOutPerSecond(flinkMetrics, jobVertexID);
 
         if (isSource) {
             double sourceDataRate = Math.max(0, numRecordsInPerSecond + lagGrowthRate);
@@ -76,6 +77,8 @@ public class ScalingMetrics {
             scalingMetrics.put(ScalingMetric.TRUE_PROCESSING_RATE, Double.NaN);
             scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, Double.NaN);
         }
+
+        scalingMetrics.put(ScalingMetric.NUM_RECORDS_OUT_PER_SECOND, numRecordsOutPerSecond);
     }
 
     public static Map<Edge, Double> computeOutputRatios(


### PR DESCRIPTION
**Description:**
This pull request introduces a new metric, `numRecordsOutPerSecond`, to enhance the capabilities of the custom autoscaler. The metric is crucial for decision-making processes related to scaling, providing valuable information about the number of records sent per second.

**Changes:**
- Added computation of `numRecordsOutPerSecond` in the `computeDataRateMetrics` method.
- Included `NUM_RECORDS_OUT_PER_SECOND` in the `ScalingMetric` enum.
- Updated relevant parts of the code to handle the new metric.

**Purpose:**
The addition of `numRecordsOutPerSecond` empowers the custom autoscaler to make more informed scaling decisions based on the output rate of job vertices, contributing to better resource allocation and system performance.

Closes #<issue_number_if_applicable>Created  numRecordsOutPerSecond for custom autoscaler  decision making.