### PR TITLE
Simplified code, writing into a single file, added BUSY_TIME_PER_SEC …

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ The code in this repository is licensed under the [Apache Software License 2](LI
 ```dockerfile
 aws ecr-public get-login-password --region us-east-1 --profile brown | docker login --username AWS --password-stdin public.ecr.aws
 
+mvn spotless:apply
+
 docker buildx build \
     --platform linux/amd64 \
     --build-arg FLINK_VERSION=1.17.2 \
-    -t public.ecr.aws/m5r4d3y5/flink-kubernetes-operator:testing-mar7-v3 \
-    .  && docker push public.ecr.aws/m5r4d3y5/flink-kubernetes-operator:testing-mar7-v3
+    -t public.ecr.aws/m5r4d3y5/flink-kubernetes-operator:testing-mar9-v6 \
+    .  && docker push public.ecr.aws/m5r4d3y5/flink-kubernetes-operator:testing-mar9-v6
 ```
 
 ## Download collected metrics & decisions from Flink K8S operator pod

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
@@ -105,22 +105,10 @@ public class ScalingExecutor {
 
         scalingInformation.addToScalingHistory(clock.instant(), scalingSummaries, conf);
 
-        LOG.info(
-                " ===> previous-parallelism-overrides {} ",
-                scalingInformation.getCurrentOverrides());
-
-        ScalingMetricJsonSender.writeAutoScalingDecisionToFile(
-                scalingInformation.getCurrentOverrides(),
-                "/tmp/previous-parallelism-overrides.json");
         // TODO uncomment for default implementation
         Map<String, String> newVertexParallelismOverrides =
                 getVertexParallelismOverrides(evaluatedMetrics, scalingSummaries);
         scalingInformation.setCurrentOverrides(newVertexParallelismOverrides);
-
-        LOG.info(" ===> newVertexParallelism {} ", newVertexParallelismOverrides);
-
-        ScalingMetricJsonSender.writeAutoScalingDecisionToFile(
-                newVertexParallelismOverrides, "/tmp/new-parallelism-overrides.json");
 
         // TODO add my service to get metrics form the custom input decision and pass it to the
         // below function

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
@@ -140,10 +140,6 @@ public abstract class ScalingMetricCollector {
             LOG.info("Metric window not full until {}", windowFullTime);
         }
 
-        // TODO: sending metrics to the REST endpoint.
-        ScalingMetricJsonSender.sendMetricsAsJson(collectedMetrics);
-        HashMap<String, String> test = ScalingMetricJsonSender.getDataFromEndpoint();
-
         return collectedMetrics;
     }
 

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricJsonSender.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricJsonSender.java
@@ -190,7 +190,10 @@ public class ScalingMetricJsonSender {
     }
 
     public static void writeCollectedMetricsToFile(
-            CollectedMetricHistory collectedMetricHistory, String fileName) {
+            CollectedMetricHistory collectedMetricHistory,
+            Map<String, String> previousParallelismOverrides,
+            Map<String, String> newParallelismOverrides,
+            String fileName) {
         try {
             ObjectMapper objectMapper = new ObjectMapper();
 
@@ -198,25 +201,14 @@ public class ScalingMetricJsonSender {
             Map<String, Object> jsonData = new HashMap<>();
             jsonData.put("jobTopology", collectedMetricHistory.getJobTopology());
             jsonData.put("metricHistory", collectedMetricHistory.getMetricHistory());
+            jsonData.put("previousParallelisms", previousParallelismOverrides);
+            jsonData.put("newParallelisms", newParallelismOverrides);
 
             // Serialize the map to JSON
             String content = objectMapper.writeValueAsString(jsonData);
             writeToFile(content, fileName);
         } catch (Exception e) {
             LOG.error("Error writeCollectedMetricsToFile", e);
-        }
-    }
-
-    public static void writeAutoScalingDecisionToFile(
-            Map<String, String> parallelismOverrides, String fileName) {
-        LOG.info("====> writeAutoScalingDecisionToFile ({},{})", parallelismOverrides, fileName);
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            // Serialize the map to JSON
-            String content = objectMapper.writeValueAsString(parallelismOverrides);
-            writeToFile(content, fileName);
-        } catch (Exception e) {
-            LOG.error("===> Error writeAutoScalingDecisionToFile", e);
         }
     }
 

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetric.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetric.java
@@ -45,7 +45,7 @@ public enum ScalingMetric {
     CATCH_UP_DATA_RATE(false),
 
     /** Total number of pending records. */
-    LAG(true),
+    LAG(false),
 
     /** Job vertex parallelism. */
     PARALLELISM(false),
@@ -61,9 +61,11 @@ public enum ScalingMetric {
     /** Lower boundary of the target data rate range. */
     SCALE_DOWN_RATE_THRESHOLD(false),
 
-    NUM_RECORDS_OUT_PER_SECOND(true),
+    NUM_RECORDS_OUT_PER_SECOND(false),
 
-    NUM_RECORDS_IN_PER_SECOND(true),
+    NUM_RECORDS_IN_PER_SECOND(false),
+
+    BUSY_TIME_PER_SEC(false),
 
     /** Expected true processing rate after scale up. */
     EXPECTED_PROCESSING_RATE(false);

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
@@ -57,6 +57,8 @@ public class ScalingMetrics {
         var isSource = topology.isSource(jobVertexID);
 
         double busyTimeMsPerSecond = getBusyTimeMsPerSecond(flinkMetrics, conf, jobVertexID);
+        scalingMetrics.put(ScalingMetric.BUSY_TIME_PER_SEC, busyTimeMsPerSecond);
+
         double numRecordsInPerSecond =
                 getNumRecordsInPerSecond(flinkMetrics, jobVertexID, isSource);
         double numRecordsOutPerSecond = getNumRecordsOutPerSecond(flinkMetrics, jobVertexID);


### PR DESCRIPTION
Simplify code add busy metrics:
- Simplified code, 
- writing into a single file, 
- added BUSY_TIME_PER_SEC metrics, 
- converted to False for ScalingMetric average